### PR TITLE
Update .gitignore to prevent node_modules and .next folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ _site
 .jekyll-metadata
 vendor
 .DS_store
+
+# Dependency directories
+node_modules/
+
+# Next.js build output
+.next


### PR DESCRIPTION
When you build locally node_modules and .next are created and they would never go into the repo so it's best to keep them in .gitignore